### PR TITLE
little fixes in quickstart guides

### DIFF
--- a/docs/ee/QUICKSTART.md
+++ b/docs/ee/QUICKSTART.md
@@ -80,8 +80,6 @@ module "dcos" {
   dcos_variant                 = "ee"
   dcos_version                 = "1.11.4"
   dcos_license_key_contents    = "LICENSE_KEY_HERE"
-  dcos_superuser_password_hash = "HASH_VALUE_GENERATED_FROM_ABOVE"
-  dcos_superuser_username      = "admin"
 }
 
 output "masters-ips" {
@@ -168,8 +166,6 @@ module "dcos" {
   dcos_variant                 = "ee"
   dcos_version                 = "1.11.4"
   dcos_license_key_contents    = "LICENSE_KEY_HERE"
-  dcos_superuser_password_hash = "HASH_VALUE_GENERATED_FROM_ABOVE"
-  dcos_superuser_username      = "admin"
 }
 
 output "masters-ips" {
@@ -243,8 +239,6 @@ module "dcos" {
   dcos_variant                 = "ee"
   dcos_version                 = "1.11.4"
   dcos_license_key_contents    = "LICENSE_KEY_HERE"
-  dcos_superuser_password_hash = "HASH_VALUE_GENERATED_FROM_ABOVE"
-  dcos_superuser_username      = "admin"
 }
 
 output "masters-ips" {

--- a/docs/open/QUICKSTART.md
+++ b/docs/open/QUICKSTART.md
@@ -255,7 +255,7 @@ module "dcos" {
   num_public_agents  = "1"
 
   dcos_variant = "open"
-  dcos_version = "1.11.5"
+  dcos_version = "1.11.4"
 }
 
 output "masters-ips" {


### PR DESCRIPTION
reset version to 1.11.4 in upgrade in open quickstart since in place upgrade.
removed hash and username variables from quickstart ee guide