### PR TITLE
quickstart: add clarifying comment for public ip

### DIFF
--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -98,6 +98,7 @@ variable "dcos_install_mode" {
   default     = "install"
 }
 
+# Used to determine your public IP for forwarding rules
 data "http" "whatismyip" {
   url = "http://whatismyip.akamai.com/"
 }


### PR DESCRIPTION
Just went through the tutorial and this part was unclear to me