### PR TITLE
docs: updating default coreos version

### DIFF
--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -106,7 +106,7 @@ data "http" "whatismyip" {
 module "dcos" {
   source = "dcos-terraform/dcos/aws"
 
-  dcos_instance_os    = "coreos_1235.9.0"
+  dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"
   admin_ips           = ["${data.http.whatismyip.body}/32"]
@@ -205,7 +205,7 @@ variable "dcos_install_mode" {
 module "dcos" {
   source = "dcos-terraform/dcos/aws"
 
-  dcos_instance_os    = "coreos_1235.9.0"
+  dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"
   admin_ips           = ["${data.http.whatismyip.body}/32"]
@@ -292,7 +292,7 @@ data "http" "whatismyip" {
 module "dcos" {
   source = "dcos-terraform/dcos/aws"
 
-  dcos_instance_os    = "coreos_1235.9.0"
+  dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"
   admin_ips           = ["${data.http.whatismyip.body}/32"]

--- a/docs/quickstart/main.tf
+++ b/docs/quickstart/main.tf
@@ -10,7 +10,7 @@ data "http" "whatismyip" {
 module "dcos" {
   source = "dcos-terraform/dcos/aws"
 
-  dcos_instance_os    = "coreos_1235.9.0"
+  dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"
   admin_ips           = ["${data.http.whatismyip.body}/32"]


### PR DESCRIPTION
We need to update the CoreOS version in our default templates from CoreOS 1235 => CoreOS 1855.5 as it is now our most supported version.

See below:
https://docs.mesosphere.com/version-policy/

https://jira.mesosphere.com/browse/DCOS-44377