### PR TITLE
docs: adding version support to convenience wrapper

### DIFF
--- a/docs/published/README.md
+++ b/docs/published/README.md
@@ -115,7 +115,8 @@ data "http" "whatismyip" {
 }
 
 module "dcos" {
-  source = "dcos-terraform/dcos/aws"
+  source  = "dcos-terraform/dcos/aws"
+  version = "~> 0.1"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"
@@ -214,7 +215,8 @@ variable "dcos_install_mode" {
 }
 
 module "dcos" {
-  source = "dcos-terraform/dcos/aws"
+  source  = "dcos-terraform/dcos/aws"
+  version = "~> 0.1"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"
@@ -301,7 +303,8 @@ data "http" "whatismyip" {
 }
 
 module "dcos" {
-  source = "dcos-terraform/dcos/aws"
+  source  = "dcos-terraform/dcos/aws"
+  version = "~> 0.1"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"

--- a/docs/published/main.tf
+++ b/docs/published/main.tf
@@ -8,7 +8,8 @@ data "http" "whatismyip" {
 }
 
 module "dcos" {
-  source = "dcos-terraform/dcos/aws"
+  source  = "dcos-terraform/dcos/aws"
+  version = "~> 0.1"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"


### PR DESCRIPTION
If an operator wanted to control the submodules in the dcos-terraform provisioner, he may need a working example of how this looks like but also it needs to be pinned at the operator level. In the event the user wanted to latest version of dcos to upgrade to, when the user subsequently runs the `terraform get --update`, not only will the dcos layer be updated,  but also the infrastructure layer. 

This change will pin the infra layer, while keeping the control of the dcos-layer free for updates as the minor version will most likely not change in the near future.