### PR TITLE
adding fail or error to ip-detect.sh per request in COPS-4180

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ module "dcos" {
 | admin_ips | List of CIDR admin IPs | list | - | yes |
 | availability_zones | Availability zones to be used | list | `<list>` | no |
 | aws_ami | AMI that will be used for the instances instead of Mesosphere provided AMIs | string | `` | no |
-| aws_key_name | Specify the aws ssh key to use. We assume its already loaded in your SSH agent. Set ssh_public_key to none | string | `` | no |
+| aws_key_name | Specify the aws ssh key to use. We assume its already loaded in your SSH agent. Set ssh_public_key_file to empty string | string | `` | no |
 | bootstrap_associate_public_ip_address | [BOOTSTRAP] Associate a public ip address with there instances | string | `true` | no |
 | bootstrap_aws_ami | [BOOTSTRAP] AMI to be used | string | `` | no |
 | bootstrap_instance_type | [BOOTSTRAP] Instance type | string | `t2.medium` | no |

--- a/scripts/ip-detect.sh
+++ b/scripts/ip-detect.sh
@@ -2,4 +2,6 @@
 # Example ip-detect script using an external authority
 # Uses the AWS Metadata Service to get the node's internal
 # ipv4 address
+set -o nounset -o errexit
+
 curl -fsSL http://169.254.169.254/latest/meta-data/local-ipv4

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "cluster_name" {
 }
 
 variable "aws_key_name" {
-  description = "Specify the aws ssh key to use. We assume its already loaded in your SSH agent. Set ssh_public_key to none"
+  description = "Specify the aws ssh key to use. We assume its already loaded in your SSH agent. Set ssh_public_key_file to empty string"
   default     = ""
 }
 


### PR DESCRIPTION
Per COPS-4180, "The detect_ip script has failed when secrets service was started by systemd. This failure resulted in missing value for -node-id flag which later picked bootstrap flag as a node-id value. The -bootstrap was then missing, which is the flag that instructs the secret service to auto unseal the default vault backend."

It was requested that we add fail on error as we do for the other scripts. Ticket for tracking this PR is DCOS-45817.