### PR TITLE
adding support for no prompt region in main.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ module "dcos" {
   source  = "dcos-terraform/dcos/aws"
   version = "~> 0.1"
 
+  providers = {
+    aws = "aws"
+  }
+
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"
   admin_ips = ["198.51.100.0/24"]

--- a/docs/published/README.md
+++ b/docs/published/README.md
@@ -39,22 +39,6 @@ For help installing Terraform on a different OS, please see [here](https://www.t
 ## Ensure you have your AWS Cloud Credentials Properly Set up
 Please follow the AWS guide [Configuring the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) how to setup your credentials.
 
-## Set the Default AWS Region
-The current Terraform Provider for AWS requires that the default AWS region be set before it can be used. You can set the default region with the following command:
-```bash
-export AWS_DEFAULT_REGION="<desired-aws-region>"
-```
-For Example:
-```bash
-export AWS_DEFAULT_REGION="us-east-1"
-```
-
-Ensure it has been set:
-```bash
-> echo $AWS_DEFAULT_REGION
-us-east-1
-```
-
 ## Add your SSH keys to your ssh agent:
 
 Terraform requires SSH access to the instances you launch as part of your DC/OS cluster. As such, we need to make sure that the SSH key used to SSH to these instances is added to your `ssh-agent`, prior to running `terraform`.
@@ -104,6 +88,10 @@ It also specifies that the following output should be printed once cluster creat
 - `public-agent-loadbalancer` - The URL of your Public routable services.
 
 ```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
 variable "dcos_install_mode" {
   description = "specifies which type of command to execute. Options: install or upgrade"
   default     = "install"
@@ -209,9 +197,18 @@ Terraform makes it easy to scale your cluster to add additional agents (public o
 
 
 ```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
 variable "dcos_install_mode" {
   description = "specifies which type of command to execute. Options: install or upgrade"
-  default = "install"
+  default     = "install"
+}
+
+# Used to determine your public IP for forwarding rules
+data "http" "whatismyip" {
+  url = "http://whatismyip.akamai.com/"
 }
 
 module "dcos" {
@@ -293,11 +290,16 @@ Since we’re now upgrading, however, we need to set this parameter to `upgrade`
 <p class="message--important"><strong>IMPORTANT: </strong>Do not change any number of masters, agents or public agents while performing an upgrade.</p>
 
 ```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
 variable "dcos_install_mode" {
   description = "specifies which type of command to execute. Options: install or upgrade"
   default     = "install"
 }
 
+# Used to determine your public IP for forwarding rules
 data "http" "whatismyip" {
   url = "http://whatismyip.akamai.com/"
 }

--- a/docs/published/main.tf
+++ b/docs/published/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
 variable "dcos_install_mode" {
   description = "specifies which type of command to execute. Options: install or upgrade"
   default     = "install"
@@ -10,6 +14,10 @@ data "http" "whatismyip" {
 module "dcos" {
   source  = "dcos-terraform/dcos/aws"
   version = "~> 0.1"
+
+  providers = {
+    aws = "aws"
+  }
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,10 @@
  *   source  = "dcos-terraform/dcos/aws"
  *   version = "~> 0.1"
  *
+ *   providers = {
+ *     aws = "aws"
+ *   }
+ *
  *   cluster_name = "mydcoscluster"
  *   ssh_public_key_file = "~/.ssh/id_rsa.pub"
  *   admin_ips = ["198.51.100.0/24"]


### PR DESCRIPTION
Many users have been wanting to set their region in the main.tf. This will be a good reason to set this not in the environment variable as we move into multi-region efforts as we do not want to set all remote regions in environment variables.
quickstart/docs: adding support for no prompt region