### PR TITLE
Fix link to quick start guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ DC/OS on AWS
 ============
 Creates a DC/OS Cluster on AWS
 
-[Quick Start Guide](https://github.com/dcos-terraform/terraform-aws-dcos/blob/master/docs/quickstart/README.md)
+[Quick Start Guide](https://github.com/dcos-terraform/terraform-aws-dcos/blob/master/docs/published/README.md)
 
 You can find more detailed documentation about this module here: [README.md](./docs/README.md)
 


### PR DESCRIPTION
The previous link was broken in b3623553e35a65ec358a6d2c7ed6a110616fe976 and I guess that this is now the correct location for the Quick Start Guide.