### PR TITLE
non breaking private network subnet_range DCOS-49565

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ module "dcos" {
 |------|-------------|:----:|:-----:|:-----:|
 | admin_ips | List of CIDR admin IPs | list | - | yes |
 | availability_zones | Availability zones to be used | list | `<list>` | no |
-| aws_ami | AMI that will be used for the instances instead of Mesosphere provided AMIs | string | `` | no |
+| aws_ami | AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/ | string | `` | no |
 | aws_key_name | Specify the aws ssh key to use. We assume its already loaded in your SSH agent. Set ssh_public_key_file to empty string | string | `` | no |
 | bootstrap_associate_public_ip_address | [BOOTSTRAP] Associate a public ip address with there instances | string | `true` | no |
 | bootstrap_aws_ami | [BOOTSTRAP] AMI to be used | string | `` | no |
@@ -224,6 +224,7 @@ module "dcos" {
 | public_agents_root_volume_type | [PUBLIC AGENTS] Specify the root volume type. | string | `gp2` | no |
 | ssh_public_key | SSH public key in authorized keys format (e.g. 'ssh-rsa ..') to be used with the instances. Make sure you added this key to your ssh-agent. | string | `` | no |
 | ssh_public_key_file | Path to SSH public key. This is mandatory but can be set to an empty string if you want to use ssh_public_key with the key as string. | string | - | yes |
+| subnet_range | Private IP space to be used in CIDR format | string | `` | no |
 | tags | Add custom tags to all resources | map | `<map>` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ module "dcos" {
 | public_agents_root_volume_type | [PUBLIC AGENTS] Specify the root volume type. | string | `gp2` | no |
 | ssh_public_key | SSH public key in authorized keys format (e.g. 'ssh-rsa ..') to be used with the instances. Make sure you added this key to your ssh-agent. | string | `` | no |
 | ssh_public_key_file | Path to SSH public key. This is mandatory but can be set to an empty string if you want to use ssh_public_key with the key as string. | string | - | yes |
-| subnet_range | Private IP space to be used in CIDR format | string | `` | no |
+| subnet_range | Private IP space to be used in CIDR format | string | `172.12.0.0/16` | no |
 | tags | Add custom tags to all resources | map | `<map>` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -133,6 +133,7 @@ module "dcos-infrastructure" {
   public_agents_additional_ports             = ["${var.public_agents_additional_ports}"]
   ssh_public_key                             = "${var.ssh_public_key}"
   ssh_public_key_file                        = "${var.ssh_public_key_file}"
+  subnet_range                               = "${var.subnet_range}"
   tags                                       = "${var.tags}"
 
   # If defining external exhibitor storage

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "availability_zones" {
 }
 
 variable "aws_ami" {
-  description = "AMI that will be used for the instances instead of Mesosphere provided AMIs"
+  description = "AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/"
   default     = ""
 }
 
@@ -214,4 +214,9 @@ variable "public_agents_access_ips" {
 variable "cluster_name_random_string" {
   description = "Add a random string to the cluster name"
   default     = false
+}
+
+variable "subnet_range" {
+  description = "Private IP space to be used in CIDR format"
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -218,5 +218,5 @@ variable "cluster_name_random_string" {
 
 variable "subnet_range" {
   description = "Private IP space to be used in CIDR format"
-  default     = "172.16.0.0/16"
+  default     = "172.12.0.0/16"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -218,5 +218,5 @@ variable "cluster_name_random_string" {
 
 variable "subnet_range" {
   description = "Private IP space to be used in CIDR format"
-  default     = ""
+  default     = "172.16.0.0/16"
 }


### PR DESCRIPTION
This PR will allow for an immediate merge and fix without introducing a breaking change for DCOS-49565 (The universal installer currently is not using the correct private IP default CIDR as specified by RFC 1918.). 

This immediate workaround introduces the `subnet_range` variable to allow for users to specify their own `subnet_range` while defaulting to current "incorrect" range. Permanent fix is a breaking change that will then be introduced in the v.0.2 release. 