### PR TITLE
updating to default AWS DNS for dhcp

### DIFF
--- a/dcos_core_variables.tf
+++ b/dcos_core_variables.tf
@@ -21,7 +21,7 @@ variable "dcos_security" {
 }
 
 variable "dcos_resolvers" {
-  default     = ["8.8.8.8", "8.8.4.4"]
+  default     = ["169.254.169.253"]
   description = "A YAML nested list (-) of DNS resolvers for your DC/OS cluster nodes. (recommended)"
 }
 


### PR DESCRIPTION
Set to AWS DNS per https://docs.aws.amazon.com/vpc/latest/userguide/VPC_DHCP_Options.html