### PR TITLE
Add config options for setting Admin Router gRPC port

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ EOF
 | additional\_windows\_private\_agent\_ips | Additional windows private agent IPs | list | `<list>` | no |
 | additional\_windows\_private\_agent\_os\_user | Additional windows private agent os user to be used for WinRM | string | `"Administrator"` | no |
 | additional\_windows\_private\_agent\_passwords | Additional windows private agent passwords to be used for WinRM | list | `<list>` | no |
+| adminrouter\_grpc\_proxy\_port |  | string | `"12379"` | no |
 | ansible\_additional\_config | Add additional config options to ansible. This is getting merged with generated defaults. Do not specify `dcos:` | string | `""` | no |
 | ansible\_bundled\_container | Docker container with bundled dcos-ansible and ansible executables | string | `"mesosphere/dcos-ansible-bundle:latest"` | no |
 | ansible\_user | The Ansible user that is used to run the Ansible Tasks. | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -157,6 +157,7 @@ module "dcos-infrastructure" {
   ssh_public_key_file                        = "${var.ssh_public_key_file}"
   subnet_range                               = "${var.subnet_range}"
   tags                                       = "${var.tags}"
+  adminrouter_grpc_proxy_port                = "${var.adminrouter_grpc_proxy_port}"
 
   aws_create_s3_bucket = "${var.with_replaceable_masters}"
 
@@ -312,4 +313,5 @@ module "dcos-install" {
   dcos_zk_master_credentials                   = "${var.dcos_zk_master_credentials}"
   dcos_zk_super_credentials                    = "${var.dcos_zk_super_credentials}"
   dcos_enable_mesos_input_plugin               = "${var.dcos_enable_mesos_input_plugin}"
+  adminrouter_grpc_proxy_port                  = "${var.adminrouter_grpc_proxy_port}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -326,3 +326,8 @@ variable "public_agents_acm_cert_arn" {
   description = "ACM certifacte to be used for the public agents load balancer"
   default     = ""
 }
+
+variable "adminrouter_grpc_proxy_port" {
+  description = ""
+  default     = 12379
+}


### PR DESCRIPTION
This PR adds support for Add config options for setting Admin Router gRPC port. See the Jira issue below for more details:

https://jira.d2iq.com/browse/D2IQ-62476