### PR TITLE
feat: add open_admin_router and open_instance_ssh option

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ EOF
 | num\_of\_public\_agents | Specify the amount of public agents. These agents will host marathon-lb and edgelb | string | `""` | no |
 | num\_private\_agents | Specify the amount of private agents. These agents will provide your main resources | string | `"2"` | no |
 | num\_public\_agents | Specify the amount of public agents. These agents will host marathon-lb and edgelb | string | `"1"` | no |
+| open\_admin\_router | Open admin router to public (80+443 on load balancer). WARNING: attackers could take over your cluster | string | `"false"` | no |
+| open\_instance\_ssh | Open SSH on instances to public. WARNING: make sure you use a strong SSH key | string | `"false"` | no |
 | private\_agents\_associate\_public\_ip\_address | [PRIVATE AGENTS] Associate a public ip address with there instances | string | `"true"` | no |
 | private\_agents\_aws\_ami | [PRIVATE AGENTS] AMI to be used | string | `""` | no |
 | private\_agents\_extra\_volumes | [PRIVATE AGENTS] Extra volumes for each private agent | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ locals {
 
 module "dcos-infrastructure" {
   source  = "dcos-terraform/infrastructure/aws"
-  version = "~> 0.2.5"
+  version = "~> 0.2.6"
 
   admin_ips                                  = "${var.admin_ips}"
   availability_zones                         = "${var.availability_zones}"
@@ -160,6 +160,8 @@ module "dcos-infrastructure" {
   subnet_range                               = "${var.subnet_range}"
   tags                                       = "${var.tags}"
   adminrouter_grpc_proxy_port                = "${var.adminrouter_grpc_proxy_port}"
+  open_admin_router                          = "${var.open_admin_router}"
+  open_instance_ssh                          = "${var.open_instance_ssh}"
 
   aws_create_s3_bucket = "${var.with_replaceable_masters}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -288,17 +288,17 @@ variable "additional_private_agent_ips" {
 }
 
 variable "additional_windows_private_agent_ips" {
-  description = "Additional windows private agent IPs"
+  description = "[DEPRECATED] Additional windows private agent IPs"
   default     = []
 }
 
 variable "additional_windows_private_agent_passwords" {
-  description = "Additional windows private agent passwords to be used for WinRM"
+  description = "[DEPRECATED] Additional windows private agent passwords to be used for WinRM"
   default     = []
 }
 
 variable "additional_windows_private_agent_os_user" {
-  description = "Additional windows private agent os user to be used for WinRM"
+  description = "[DEPRECATED] Additional windows private agent os user to be used for WinRM"
   default     = "Administrator"
 }
 
@@ -340,4 +340,14 @@ variable "public_agents_acm_cert_arn" {
 variable "adminrouter_grpc_proxy_port" {
   description = ""
   default     = 12379
+}
+
+variable "open_admin_router" {
+  description = "Open admin router to public (80+443 on load balancer). WARNING: attackers could take over your cluster"
+  default     = false
+}
+
+variable "open_instance_ssh" {
+  description = "Open SSH on instances to public. WARNING: make sure you use a strong SSH key"
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -288,17 +288,17 @@ variable "additional_private_agent_ips" {
 }
 
 variable "additional_windows_private_agent_ips" {
-  description = "[DEPRECATED] Additional windows private agent IPs"
+  description = "Additional windows private agent IPs"
   default     = []
 }
 
 variable "additional_windows_private_agent_passwords" {
-  description = "[DEPRECATED] Additional windows private agent passwords to be used for WinRM"
+  description = "Additional windows private agent passwords to be used for WinRM"
   default     = []
 }
 
 variable "additional_windows_private_agent_os_user" {
-  description = "[DEPRECATED] Additional windows private agent os user to be used for WinRM"
+  description = "Additional windows private agent os user to be used for WinRM"
   default     = "Administrator"
 }
 


### PR DESCRIPTION
- adds the possibility to open SSH or master admin router to public without opening the complete admin_ips port ranges