### PR TITLE
fix: bad version matcher. Stay with 2.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@
  */
 
 provider "aws" {
-  version = ">= 2.58"
+  version = "~> 2.58"
 }
 
 provider "random" {


### PR DESCRIPTION
we must keep the 2.x release of AWS provider.

fix: [COPS-6621](https://jira.d2iq.com/browse/COPS-6621)